### PR TITLE
Exposing basepath as a member of IApiDescription; no longer hardcoded.

### DIFF
--- a/src/Nancy.OpenApi.WebHost/ApiDescription.cs
+++ b/src/Nancy.OpenApi.WebHost/ApiDescription.cs
@@ -16,5 +16,6 @@
         public string Version => Resources.Version;
         public string ExternalDocsDescription => Resources.ExternalDocsDescription;
         public string ExternalDocsUrl => Resources.ExternalDocsUrl;
+        public string BasePath => Resources.BasePath;
     }
 }

--- a/src/Nancy.OpenApi.WebHost/Resources.Designer.cs
+++ b/src/Nancy.OpenApi.WebHost/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Nancy.OpenApi.WebHost {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to v2.
+        /// </summary>
+        internal static string BasePath {
+            get {
+                return ResourceManager.GetString("BasePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to joe.bloggs@somewhere.com.
         /// </summary>
         internal static string ContactEmail {

--- a/src/Nancy.OpenApi.WebHost/Resources.resx
+++ b/src/Nancy.OpenApi.WebHost/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BasePath" xml:space="preserve">
+    <value>v2</value>
+  </data>
   <data name="ContactEmail" xml:space="preserve">
     <value>joe.bloggs@somewhere.com</value>
   </data>

--- a/src/Nancy.OpenApi/IApiDescription.cs
+++ b/src/Nancy.OpenApi/IApiDescription.cs
@@ -16,5 +16,6 @@ namespace Nancy.OpenApi
         string Version { get; }
         string ExternalDocsDescription { get; }
         string ExternalDocsUrl { get; }
+        string BasePath { get; }
     }
 }

--- a/src/Nancy.OpenApi/Mappers/OpenApiMapper.cs
+++ b/src/Nancy.OpenApi/Mappers/OpenApiMapper.cs
@@ -30,7 +30,8 @@ namespace Nancy.OpenApi.Mappers
                     },
                     TermsOfService = apiDescription.TermsOfService,
                     Version = apiDescription.Version
-                }
+                },
+                BasePath = apiDescription.BasePath
             };
         }
     }

--- a/src/Nancy.OpenApi/Models/ApiSpecification.cs
+++ b/src/Nancy.OpenApi/Models/ApiSpecification.cs
@@ -5,7 +5,7 @@ namespace Nancy.OpenApi.Models
     public class ApiSpecification
     {
         public string Swagger => "2.0";
-        public string BasePath => "v2";
+        public string BasePath { get; set; }
         public string Host { get; set; }
         public List<string> Schemes { get; set; }
         public List<string> Consumes { get; set; }

--- a/tests/Nancy.OpenApi.Tests/Fakes/FakeApiDescription.cs
+++ b/tests/Nancy.OpenApi.Tests/Fakes/FakeApiDescription.cs
@@ -15,5 +15,6 @@ namespace Nancy.OpenApi.Tests.Fakes
         public string Version => "1.0";
         public string ExternalDocsDescription => "Wiki community article";
         public string ExternalDocsUrl => "www.testdocs";
+        public string BasePath => "v2";
     }
 }

--- a/tests/Nancy.OpenApi.Tests/GivenOpenApiModule.cs
+++ b/tests/Nancy.OpenApi.Tests/GivenOpenApiModule.cs
@@ -38,6 +38,7 @@ namespace Nancy.OpenApi.Tests
 
             Assert.That(specs, Is.Not.Null);
             Assert.That(specs.Swagger, Is.EqualTo("2.0"));
+            Assert.That(specs.BasePath, Is.EqualTo(_apiDescription.BasePath));
             Assert.That(specs.Info.Contact.Name, Is.EqualTo(_apiDescription.ContactName));
             Assert.That(specs.Info.Contact.Email, Is.EqualTo(_apiDescription.ContactEmail));
             Assert.That(specs.Info.Contact.Url, Is.EqualTo(_apiDescription.ContactUrl));


### PR DESCRIPTION
Really appreciate the work you've done so far; for this to be generic we can't have this basepath hardcoded to 'v2'.