### PR TITLE
Use SafeGetTypes

### DIFF
--- a/src/Nancy.OpenApi/Infrastructure/RouteMetadataProvider.cs
+++ b/src/Nancy.OpenApi/Infrastructure/RouteMetadataProvider.cs
@@ -45,7 +45,7 @@ namespace Nancy.OpenApi.Infrastructure
             if (ModuleTypes.TryGetValue(metadataName, out type)) return type;
 
             type = AppDomain.CurrentDomain.GetAssemblies()
-                            .SelectMany(x => x.GetTypes())
+                            .SelectMany(x => x.SafeGetTypes())
                             .FirstOrDefault(x => x.Name == metadataName);
 
             ModuleTypes.Add(metadataName, type);


### PR DESCRIPTION
`GetTypes()` will attempt to load all dependencies of the currently loaded assemblies when searching for Metadata Modules.  This caused some of my larger projects to fail to load as some of the dependencies are not required for it to run.

Using the `SafeGetTypes()` adds necessary type load exception handling which I believe to be preferable in this scenario.

https://github.com/NancyFx/Nancy/blob/master/src/Nancy/TinyIoc/TinyIoC.cs#L328 